### PR TITLE
feat: add multi-signature utilities

### DIFF
--- a/chain-api/src/utils/index.ts
+++ b/chain-api/src/utils/index.ts
@@ -2,7 +2,7 @@ import deserialize from "./deserialize";
 import { Primitive, generateResponseSchema, generateSchema } from "./generate-schema";
 import { ValidationErrorInfo, getValidationErrorInfo } from "./getValidationErrorMessage";
 import serialize from "./serialize";
-import signatures from "./signatures";
+import signatures, { isValidMulti, recoverPublicKeys } from "./signatures";
 
 /*
  * Copyright (c) Gala Games Inc. All rights reserved.
@@ -31,5 +31,7 @@ export {
   getValidationErrorInfo,
   ValidationErrorInfo,
   Primitive,
-  signatures
+  signatures,
+  isValidMulti,
+  recoverPublicKeys
 };

--- a/chain-api/src/utils/signatures.spec.ts
+++ b/chain-api/src/utils/signatures.spec.ts
@@ -29,9 +29,9 @@ describe("getPayloadToSign", () => {
     expect(toSign).toEqual('{"a":3,"b":[{"x":4,"y":5,"z":6},7],"c":8}');
   });
 
-  it("should ignore 'signature' and 'trace' fields", () => {
+  it("should ignore 'signature', 'signatures' and 'trace' fields", () => {
     // Given
-    const obj = { c: 8, signature: "to-be-ignored", trace: 3 };
+    const obj = { c: 8, signature: "to-be-ignored", signatures: ["a", "b"], trace: 3 };
 
     // When
     const toSign = signatures.getPayloadToSign(obj);
@@ -237,6 +237,36 @@ describe("signatures", () => {
 
     // Then
     await expect(actual).rejects.toThrowError(/Signature must contain recovery part/);
+  });
+
+  describe("multi-signatures", () => {
+    const privateKey2 = "313871326028141e0bdeef59fe32a6fc51bce449e44907c191558cb6fdca1341";
+    const publicKey2 =
+      "04651b1e822f794444fbc96424da6b3536e725c92dbe0047f357cec15fbe5ff148ef0d0d37affaf4ee1d6d0da680bdbd177240913353c6792a60be6ddfb1ce25fb";
+
+    const sig1 = signatures.getSignature(payload, signatures.normalizePrivateKey(privateKey));
+    const sig2 = signatures.getSignature(payload, signatures.normalizePrivateKey(privateKey2));
+
+    it("should verify multiple signatures", () => {
+      const result = signatures.isValidMulti([sig1, sig2], payload, [publicKey, publicKey2]);
+      expect(result).toEqual(true);
+    });
+
+    it("should recover public keys from multiple signatures", () => {
+      const keys = signatures.recoverPublicKeys([sig1, sig2], payload);
+      expect(keys).toEqual([publicKey, publicKey2]);
+    });
+
+    it("should fail if any signature invalid", () => {
+      const invalid = "aa" + sig2.substring(2);
+      const result = signatures.isValidMulti([sig1, invalid], payload, [publicKey, publicKey2]);
+      expect(result).toEqual(false);
+    });
+
+    it("should fail when counts do not match", () => {
+      const result = signatures.isValidMulti([sig1], payload, [publicKey, publicKey2]);
+      expect(result).toEqual(false);
+    });
   });
 
   it("Test multiple formats for each der signature length", async () => {

--- a/chain-api/src/utils/signatures.ts
+++ b/chain-api/src/utils/signatures.ts
@@ -29,7 +29,7 @@ class InvalidDataHashError extends ValidationFailedError {}
 
 function getPayloadToSign(obj: object): string {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { signature, trace, ...plain } = instanceToPlain(obj);
+  const { signature, signatures, trace, ...plain } = instanceToPlain(obj);
   return serialize(plain);
 }
 
@@ -312,6 +312,13 @@ function isValid(signature: string, obj: object, publicKey: string): boolean {
   return isValidSecp256k1Signature(signatureObj, dataHash, publicKeyBuffer);
 }
 
+function isValidMulti(signatures: string[], obj: object, publicKeys: string[]): boolean {
+  if (signatures.length !== publicKeys.length) {
+    return false;
+  }
+  return signatures.every((sig, idx) => isValid(sig, obj, publicKeys[idx]));
+}
+
 function validatePublicKey(publicKey: Buffer): void {
   validateSecp256k1PublicKey(publicKey);
 }
@@ -347,6 +354,10 @@ function enforceValidPublicKey(
   }
 }
 
+function recoverPublicKeys(signatures: string[], obj: object): string[] {
+  return signatures.map((sig) => recoverPublicKey(sig, obj));
+}
+
 export default {
   calculateKeccak256,
   enforceValidPublicKey,
@@ -358,11 +369,15 @@ export default {
   getSignature,
   getDERSignature,
   isValid,
+  isValidMulti,
   isValidSecp256k1Signature,
   normalizePrivateKey,
   normalizePublicKey,
   normalizeSecp256k1Signature,
   recoverPublicKey,
+  recoverPublicKeys,
   validatePublicKey,
   validateSecp256k1PublicKey
 } as const;
+
+export { isValidMulti, recoverPublicKeys };


### PR DESCRIPTION
## Summary
- support multi-signature verification and public key recovery
- export new helpers for other packages
- ensure signing payload ignores `signatures` arrays

## Testing
- ⚠️ `npx nx test chain-api` (fails: should parse TestDtoWithArray)
- ✅ `npx nx test chain-api --testFile=src/utils/signatures.spec.ts`
- ✅ `npx nx lint chain-api`


------
https://chatgpt.com/codex/tasks/task_b_68c33cb83e5083318a9ab51f9e3b28ba